### PR TITLE
Modified find records to accept an optional retrieved details parameter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,6 @@
     "linebreak-style": ["error", "unix"],
     "no-console": ["warn", { "allow": ["warn", "error"] }],
     "no-unused-vars": ["error", { "vars": "all", "args": "none" }],
-    "quotes": ["error", "single", { "allowTemplateLiterals": true }],
     "semi": ["error", "always"]
   },
   "env": {

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -384,21 +384,35 @@ class Patient extends FHIRObject {
     }
   }
 
-  findRecords(profile) {
-    const classInfo = this._modelInfo.findClass(profile);
-    if (classInfo == null) {
-      console.error(`Failed to find type info for ${profile}`);
-      return [];
+  findRecords(profile, retrievedDetails) {
+    let classInfo;
+    if (retrievedDetails) {
+      classInfo = this._modelInfo.findClass(retrievedDetails.dataType);
+      const resourceType = classInfo.name.replace(/^FHIR\./, '');
+      const records = this._bundle.entry
+        .filter(e => {
+          return e.resource && e.resource.resourceType == resourceType;
+        })
+        .map(e => {
+          return new FHIRObject(e.resource, classInfo, this._modelInfo);
+        });
+      return records;
+    } else {
+      classInfo = this._modelInfo.findClass(profile);
+      if (classInfo == null) {
+        console.error(`Failed to find type info for ${profile}`);
+        return [];
+      }
+      const resourceType = classInfo.name.replace(/^FHIR\./, '');
+      const records = this._bundle.entry
+        .filter(e => {
+          return e.resource && e.resource.resourceType == resourceType;
+        })
+        .map(e => {
+          return new FHIRObject(e.resource, classInfo, this._modelInfo);
+        });
+      return records;
     }
-    const resourceType = classInfo.name.replace(/^FHIR\./, '');
-    const records = this._bundle.entry
-      .filter(e => {
-        return e.resource && e.resource.resourceType == resourceType;
-      })
-      .map(e => {
-        return new FHIRObject(e.resource, classInfo, this._modelInfo);
-      });
-    return records;
   }
 }
 

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -393,11 +393,63 @@ class Patient extends FHIRObject {
     }
   }
 
-  findRecords(profile) {
-    const classInfo = this._modelInfo.findClass(profile);
-    if (classInfo == null) {
-      console.error(`Failed to find type info for ${profile}`);
-      return [];
+  findRecords(profile, retrievedDetails) {
+    let classInfo;
+    if (retrievedDetails) {
+      classInfo = this._modelInfo.findClass(retrievedDetails.dataType);
+      
+      if (classInfo == null) {
+        // fallback search by meta.profile
+        return this._bundle.entry
+          .filter(e => {
+            return (
+              e.resource &&
+              e.resource.meta &&
+              e.resource.meta.profile &&
+              e.resource.meta.profile.includes(profile)
+            );
+          })
+          .map(e => {
+            classInfo = this._modelInfo.findClass(e.resource.resourceType);
+            return new FHIRObject(e.resource, classInfo, this._modelInfo);
+          });
+      }
+      const resourceType = classInfo.name.replace(/^FHIR\./, '');
+      const records = this._bundle.entry
+        .filter(e => {
+          return e.resource && e.resource.resourceType == resourceType;
+        })
+        .map(e => {
+          return new FHIRObject(e.resource, classInfo, this._modelInfo);
+        });
+      return records;
+    } else {
+      classInfo = this._modelInfo.findClass(profile);
+      if (classInfo == null) {
+        // fallback search by meta.profile
+        return this._bundle.entry
+          .filter(e => {
+            return (
+              e.resource &&
+              e.resource.meta &&
+              e.resource.meta.profile &&
+              e.resource.meta.profile.includes(profile)
+            );
+          })
+          .map(e => {
+            classInfo = this._modelInfo.findClass(e.resource.resourceType);
+            return new FHIRObject(e.resource, classInfo, this._modelInfo);
+          });
+      }
+      const resourceType = classInfo.name.replace(/^FHIR\./, '');
+      const records = this._bundle.entry
+        .filter(e => {
+          return e.resource && e.resource.resourceType == resourceType;
+        })
+        .map(e => {
+          return new FHIRObject(e.resource, classInfo, this._modelInfo);
+        });
+      return records;
     }
     const resourceType = classInfo.name.replace(/^FHIR\./, '');
     const records = this._bundle.entry

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -678,7 +678,7 @@ function toCode(f) {
   }
 }
 function getClassInfo(profile, retrievedDetails, _modelInfo) {
-  let classInfo = [];
+  let classInfo = null;
   if (retrievedDetails) {
     classInfo = _modelInfo.findClass(retrievedDetails.datatype);
   } else {

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -384,35 +384,21 @@ class Patient extends FHIRObject {
     }
   }
 
-  findRecords(profile, retrievedDetails) {
-    let classInfo;
-    if (retrievedDetails) {
-      classInfo = this._modelInfo.findClass(retrievedDetails.dataType);
-      const resourceType = classInfo.name.replace(/^FHIR\./, '');
-      const records = this._bundle.entry
-        .filter(e => {
-          return e.resource && e.resource.resourceType == resourceType;
-        })
-        .map(e => {
-          return new FHIRObject(e.resource, classInfo, this._modelInfo);
-        });
-      return records;
-    } else {
-      classInfo = this._modelInfo.findClass(profile);
-      if (classInfo == null) {
-        console.error(`Failed to find type info for ${profile}`);
-        return [];
-      }
-      const resourceType = classInfo.name.replace(/^FHIR\./, '');
-      const records = this._bundle.entry
-        .filter(e => {
-          return e.resource && e.resource.resourceType == resourceType;
-        })
-        .map(e => {
-          return new FHIRObject(e.resource, classInfo, this._modelInfo);
-        });
-      return records;
+  findRecords(profile) {
+    const classInfo = this._modelInfo.findClass(profile);
+    if (classInfo == null) {
+      console.error(`Failed to find type info for ${profile}`);
+      return [];
     }
+    const resourceType = classInfo.name.replace(/^FHIR\./, '');
+    const records = this._bundle.entry
+      .filter(e => {
+        return e.resource && e.resource.resourceType == resourceType;
+      })
+      .map(e => {
+        return new FHIRObject(e.resource, classInfo, this._modelInfo);
+      });
+    return records;
   }
 }
 

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -394,33 +394,11 @@ class Patient extends FHIRObject {
   }
 
   findRecords(profile, retrievedDetails) {
-    let classInfo;
-    if (retrievedDetails) {
-      classInfo = this._modelInfo.findClass(retrievedDetails.dataType);
-      const resourceType = classInfo.name.replace(/^FHIR\./, '');
-      const records = this._bundle.entry
-        .filter(e => {
-          return e.resource && e.resource.resourceType == resourceType;
-        })
-        .map(e => {
-          return new FHIRObject(e.resource, classInfo, this._modelInfo);
-        });
-      return records;
-    } else {
-      classInfo = this._modelInfo.findClass(profile);
-      if (classInfo == null) {
-        console.error(`Failed to find type info for ${profile}`);
-        return [];
-      }
-      const resourceType = classInfo.name.replace(/^FHIR\./, '');
-      const records = this._bundle.entry
-        .filter(e => {
-          return e.resource && e.resource.resourceType == resourceType;
-        })
-        .map(e => {
-          return new FHIRObject(e.resource, classInfo, this._modelInfo);
-        });
-      return records;
+    const classInfo = getClassInfo(profile, retrievedDetails, this._modelInfo);
+
+    if (classInfo == null) {
+      console.error(`Failed to find type info for ${profile}`);
+      return [];
     }
     const resourceType = classInfo.name.replace(/^FHIR\./, '');
     const records = this._bundle.entry
@@ -462,8 +440,8 @@ class AsyncPatient extends FHIRObject {
     this._shouldCheckProfile = shouldCheckProfile;
   }
 
-  async findRecords(profile) {
-    const classInfo = this._modelInfo.findClass(profile);
+  async findRecords(profile, retrievedDetails) {
+    const classInfo = getClassInfo(profile, retrievedDetails, this._modelInfo);
     if (classInfo == null) {
       console.error(`Failed to find type info for ${profile}`);
       return [];
@@ -699,7 +677,16 @@ function toCode(f) {
     return f.value;
   }
 }
+function getClassInfo(profile, retrievedDetails, _modelInfo) {
+  let classInfo = [];
+  if (retrievedDetails) {
+    classInfo = _modelInfo.findClass(retrievedDetails.datatype);
+  } else {
+    classInfo = _modelInfo.findClass(profile);
+  }
 
+  return classInfo;
+}
 module.exports = {
   PatientSource,
   FHIRWrapper,

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -393,8 +393,8 @@ class Patient extends FHIRObject {
     }
   }
 
-  findRecords(profile, retrievedDetails) {
-    const classInfo = getClassInfo(profile, retrievedDetails, this._modelInfo);
+  findRecords(profile, retrieveDetails) {
+    const classInfo = getClassInfo(profile, retrieveDetails, this._modelInfo);
 
     if (classInfo == null) {
       console.error(`Failed to find type info for ${profile}`);
@@ -440,8 +440,8 @@ class AsyncPatient extends FHIRObject {
     this._shouldCheckProfile = shouldCheckProfile;
   }
 
-  async findRecords(profile, retrievedDetails) {
-    const classInfo = getClassInfo(profile, retrievedDetails, this._modelInfo);
+  async findRecords(profile, retrieveDetails) {
+    const classInfo = getClassInfo(profile, retrieveDetails, this._modelInfo);
     if (classInfo == null) {
       console.error(`Failed to find type info for ${profile}`);
       return [];
@@ -677,10 +677,10 @@ function toCode(f) {
     return f.value;
   }
 }
-function getClassInfo(profile, retrievedDetails, _modelInfo) {
+function getClassInfo(profile, retrieveDetails, _modelInfo) {
   let classInfo = null;
-  if (retrievedDetails) {
-    classInfo = _modelInfo.findClass(retrievedDetails.datatype);
+  if (retrieveDetails) {
+    classInfo = _modelInfo.findClass(retrieveDetails.datatype);
   } else {
     classInfo = _modelInfo.findClass(profile);
   }

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -397,23 +397,6 @@ class Patient extends FHIRObject {
     let classInfo;
     if (retrievedDetails) {
       classInfo = this._modelInfo.findClass(retrievedDetails.dataType);
-      
-      if (classInfo == null) {
-        // fallback search by meta.profile
-        return this._bundle.entry
-          .filter(e => {
-            return (
-              e.resource &&
-              e.resource.meta &&
-              e.resource.meta.profile &&
-              e.resource.meta.profile.includes(profile)
-            );
-          })
-          .map(e => {
-            classInfo = this._modelInfo.findClass(e.resource.resourceType);
-            return new FHIRObject(e.resource, classInfo, this._modelInfo);
-          });
-      }
       const resourceType = classInfo.name.replace(/^FHIR\./, '');
       const records = this._bundle.entry
         .filter(e => {
@@ -426,20 +409,8 @@ class Patient extends FHIRObject {
     } else {
       classInfo = this._modelInfo.findClass(profile);
       if (classInfo == null) {
-        // fallback search by meta.profile
-        return this._bundle.entry
-          .filter(e => {
-            return (
-              e.resource &&
-              e.resource.meta &&
-              e.resource.meta.profile &&
-              e.resource.meta.profile.includes(profile)
-            );
-          })
-          .map(e => {
-            classInfo = this._modelInfo.findClass(e.resource.resourceType);
-            return new FHIRObject(e.resource, classInfo, this._modelInfo);
-          });
+        console.error(`Failed to find type info for ${profile}`);
+        return [];
       }
       const resourceType = classInfo.name.replace(/^FHIR\./, '');
       const records = this._bundle.entry

--- a/test/dstu2_test.js
+++ b/test/dstu2_test.js
@@ -340,7 +340,7 @@ describe('#DSTU2', () => {
   it('should support id on list of primitives', () => {
     const pt = patientSource.currentPatient();
     expect(compact(pt.get('address')[0].get('line'))).to.deep.equal([
-      { value: '172 O\'Keefe Station' },
+      { value: "172 O'Keefe Station" },
       { id: '2468', value: 'Floor 5' },
       { value: 'Apt. C' }
     ]);

--- a/test/dstu2_test.js
+++ b/test/dstu2_test.js
@@ -340,7 +340,7 @@ describe('#DSTU2', () => {
   it('should support id on list of primitives', () => {
     const pt = patientSource.currentPatient();
     expect(compact(pt.get('address')[0].get('line'))).to.deep.equal([
-      { value: "172 O'Keefe Station" },
+      { value: '172 O\'Keefe Station' },
       { id: '2468', value: 'Floor 5' },
       { value: 'Apt. C' }
     ]);

--- a/test/fixtures/qicore4/tests-denom-EXM124-bundle.json
+++ b/test/fixtures/qicore4/tests-denom-EXM124-bundle.json
@@ -1,0 +1,113 @@
+{
+  "resourceType": "Bundle",
+  "id": "tests-denom-EXM124-bundle",
+  "type": "transaction",
+  "entry": [ {
+    "resource": {
+      "resourceType": "Encounter",
+      "id": "denom-EXM124-2",
+      "meta": {
+        "profile": [ "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter", "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter" ]
+      },
+      "status": "finished",
+      "class": {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "AMB",
+        "display": "ambulatory"
+      },
+      "type": [ {
+        "coding": [ {
+          "system": "http://www.ama-assn.org/go/cpt",
+          "code": "99201",
+          "display": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family."
+        } ]
+      } ],
+      "subject": {
+        "reference": "Patient/denom-EXM124"
+      },
+      "period": {
+        "start": "2019-01-01T01:00:00.0",
+        "end": "2019-01-02T01:00:00.0"
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Encounter/denom-EXM124-2"
+    }
+  }, {
+    "resource": {
+      "resourceType": "Observation",
+      "id": "denom-EXM124-3",
+      "meta": {
+        "profile": [ "http://hl7.org/fhir/observation" ]
+      },
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://loinc.org",
+          "code": "10524-7",
+          "display": "Microscopic observation [Identifier] in Cervix by Cyto stain"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/denom-EXM124"
+      },
+      "effectiveDateTime": "2019-11-01T00:00:00"
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/denom-EXM124-3"
+    }
+  }, {
+    "resource": {
+      "resourceType": "Patient",
+      "id": "denom-EXM124",
+      "meta": {
+        "profile": [ "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient", "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" ]
+      },
+      "extension": [ {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+        "extension": [ {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2028-9",
+            "display": "Asian"
+          }
+        } ]
+      }, {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+        "extension": [ {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2135-2",
+            "display": "Hispanic or Latino"
+          }
+        } ]
+      } ],
+      "identifier": [ {
+        "use": "usual",
+        "type": {
+          "coding": [ {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          } ]
+        },
+        "system": "http://hospital.smarthealthit.org",
+        "value": "999999995"
+      } ],
+      "name": [ {
+        "family": "Bertha",
+        "given": [ "Betty" ]
+      } ],
+      "gender": "female",
+      "birthDate": "1995-01-01"
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Patient/denom-EXM124"
+    }
+  } ]
+}

--- a/test/fixtures/qicore4/tests-numer-EXM124-bundle.json
+++ b/test/fixtures/qicore4/tests-numer-EXM124-bundle.json
@@ -1,0 +1,114 @@
+{
+  "resourceType": "Bundle",
+  "id": "tests-numer-EXM124-bundle",
+  "type": "transaction",
+  "entry": [ {
+    "resource": {
+      "resourceType": "Encounter",
+      "id": "numer-EXM124-2",
+      "meta": {
+        "profile": [ "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter", "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter" ]
+      },
+      "status": "finished",
+      "class": {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "AMB",
+        "display": "ambulatory"
+      },
+      "type": [ {
+        "coding": [ {
+          "system": "http://www.ama-assn.org/go/cpt",
+          "code": "99201",
+          "display": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family."
+        } ]
+      } ],
+      "subject": {
+        "reference": "Patient/numer-EXM124"
+      },
+      "period": {
+        "start": "2019-01-01T00:00:00.0",
+        "end": "2019-01-02T00:00:00.0"
+      }
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Encounter/numer-EXM124-2"
+    }
+  }, {
+    "resource": {
+      "resourceType": "Observation",
+      "id": "numer-EXM124-3",
+      "meta": {
+        "profile": [ "http://hl7.org/fhir/observation" ]
+      },
+      "status": "final",
+      "code": {
+        "coding": [ {
+          "system": "http://loinc.org",
+          "code": "10524-7",
+          "display": "Microscopic observation [Identifier] in Cervix by Cyto stain"
+        } ]
+      },
+      "subject": {
+        "reference": "Patient/numer-EXM124"
+      },
+      "effectiveDateTime": "2019-11-01T00:00:00",
+      "valueBoolean": true
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Observation/numer-EXM124-3"
+    }
+  }, {
+    "resource": {
+      "resourceType": "Patient",
+      "id": "numer-EXM124",
+      "meta": {
+        "profile": [ "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient", "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" ]
+      },
+      "extension": [ {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+        "extension": [ {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2028-9",
+            "display": "Asian"
+          }
+        } ]
+      }, {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+        "extension": [ {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2135-2",
+            "display": "Hispanic or Latino"
+          }
+        } ]
+      } ],
+      "identifier": [ {
+        "use": "usual",
+        "type": {
+          "coding": [ {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          } ]
+        },
+        "system": "http://hospital.smarthealthit.org",
+        "value": "999999995"
+      } ],
+      "name": [ {
+        "family": "Brigand",
+        "given": [ "Melanie" ]
+      } ],
+      "gender": "female",
+      "birthDate": "1995-01-01"
+    },
+    "request": {
+      "method": "PUT",
+      "url": "Patient/numer-EXM124"
+    }
+  } ]
+}

--- a/test/qicore410_test.js
+++ b/test/qicore410_test.js
@@ -1,0 +1,135 @@
+const cql = require('cql-execution');
+const cqlfhir = require('../src/index');
+const {expect} = require('chai');
+
+const patientNumer = require('./fixtures/qicore4/tests-numer-EXM124-bundle.json');
+const patientDenom = require('./fixtures/qicore4/tests-denom-EXM124-bundle.json');
+
+describe('#R4 v4.0.1 with QICore 4.1.0 Data', () => {
+  let patientSource;
+  before(() => {
+    patientSource = cqlfhir.PatientSource.FHIRv401();
+  });
+
+  beforeEach(() => {
+    patientSource.loadBundles([
+      patientNumer,
+      patientDenom
+    ]);
+  });
+
+  afterEach(() => patientSource.reset());
+
+
+  it('should properly iterate test patients', () => {
+    // Check first patient
+    const numer = patientSource.currentPatient();
+    expect(numer.getId()).to.equal('numer-EXM124');
+    // Check next patient
+    const denom = patientSource.nextPatient();
+    expect(denom.getId()).to.equal('denom-EXM124');
+    // No more patients should result in undefined
+    expect(patientSource.nextPatient()).to.be.undefined;
+    expect(patientSource.currentPatient()).to.be.undefined;
+  });
+
+  it('should set the current patient to the next when nextPatient is called', () => {
+    const originalCurrent = patientSource.currentPatient();
+    const nextPatient = patientSource.nextPatient();
+    const newCurrent = patientSource.currentPatient();
+    expect(newCurrent).not.to.deep.equal(originalCurrent);
+    expect(newCurrent).to.deep.equal(nextPatient);
+  });
+
+  it('should clone currentPatient each time it is called', () => {
+    expect(patientSource.currentPatient()).to.deep.equal(patientSource.currentPatient());
+    expect(patientSource.currentPatient()).to.not.equal(patientSource.currentPatient());
+  });
+
+  it('should find patient birthDate', () =>{
+    const pt = patientSource.currentPatient();
+    // cql-execution v1.3.2 currently doesn't export the new Date class, so we need to use the .getDate() workaround
+    expect(compact(pt.get('birthDate'))).to.deep.equal({ value: new cql.DateTime.parse('1995-01-01').getDate() });
+    expect(pt.get('birthDate.value')).to.deep.equal(new cql.DateTime.parse('1995-01-01').getDate());
+  });
+
+  it('should find patient extensions', () =>{
+    const pt = patientSource.currentPatient();
+    const extensions = pt.get('extension');
+    expect(extensions).to.have.length(2);
+    //Check the first and last ones
+    expect(compact(extensions[0])).to.deep.equal({
+      url: { value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race' },
+      extension: [ {
+        url: { value: 'ombCategory' },
+        value: {
+          system: { value: 'urn:oid:2.16.840.1.113883.6.238' },
+          code: { value: '2028-9' },
+          display: { value: 'Asian' }
+        }
+      } ]
+    });
+  });
+
+  it('should find records by type name (e.g., Encounter)', () =>{
+    const pt = patientSource.currentPatient();
+    const encounters = pt.findRecords('Encounter');
+    expect(encounters).to.have.length(1);
+    expect(encounters.every(c => c.getTypeInfo().name === 'Encounter')).to.be.true;
+    const paymentReconciliations = pt.findRecords('PaymentReconciliation');
+    expect(paymentReconciliations).to.be.empty;
+  });
+
+  it('should find records by model name and type name (e.g., FHIR.Encounter)', () =>{
+    const pt = patientSource.currentPatient();
+    const encounters = pt.findRecords('FHIR.Encounter');
+    expect(encounters).to.have.length(1);
+    expect(encounters.every(c => c.getTypeInfo().name === 'Encounter')).to.be.true;
+    const paymentReconciliations = pt.findRecords('FHIR.PaymentReconciliation');
+    expect(paymentReconciliations).to.be.empty;
+  });
+
+  it('should find records by model URL and type name (e.g., {http://hl7.org/fhir}Encounter)', () =>{
+    const pt = patientSource.currentPatient();
+    const encounters = pt.findRecords('{http://hl7.org/fhir}Encounter');
+    expect(encounters).to.have.length(1);
+    expect(encounters.every(c => c.getTypeInfo().name === 'Encounter')).to.be.true;
+    const paymentReconciliations = pt.findRecords('{http://hl7.org/fhir}PaymentReconciliation');
+    expect(paymentReconciliations).to.be.empty;
+  });
+
+  it('should find records by QICore profile URL (e.g., http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter)', () =>{
+    const pt = patientSource.currentPatient();
+    const encounters = pt.findRecords('http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter');
+    expect(encounters).to.have.length(1);
+    expect(encounters.every(c => c.getTypeInfo().name === 'Encounter')).to.be.true;
+    const coverage = pt.findRecords('http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage');
+    expect(coverage).to.be.empty;
+  });
+
+  it('should find a single record', () =>{
+    const pt = patientSource.currentPatient();
+    const encounter = pt.findRecord('Encounter');
+    expect(encounter.getTypeInfo().name).to.equal('Encounter');
+    expect(encounter.getId()).to.equal('numer-EXM124-2');
+    const paymentReconciliation = pt.findRecord('PaymentReconciliation');
+    expect(paymentReconciliation).to.be.undefined;
+  });
+});
+
+function compact(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(o => compact(o));
+  } else if (obj == null || typeof obj !== 'object') {
+    return obj;
+  }
+  const compacted = {};
+  for (const prop in obj) {
+    const value = obj[prop];
+    if (value !== undefined) {
+      compacted[prop] = compact(value);
+    }
+
+  }
+  return compacted;
+}

--- a/test/qicore410_test.js
+++ b/test/qicore410_test.js
@@ -1,6 +1,6 @@
 const cql = require('cql-execution');
 const cqlfhir = require('../src/index');
-const {expect} = require('chai');
+const { expect } = require('chai');
 
 const patientNumer = require('./fixtures/qicore4/tests-numer-EXM124-bundle.json');
 const patientDenom = require('./fixtures/qicore4/tests-denom-EXM124-bundle.json');
@@ -12,14 +12,10 @@ describe('#R4 v4.0.1 with QICore 4.1.0 Data', () => {
   });
 
   beforeEach(() => {
-    patientSource.loadBundles([
-      patientNumer,
-      patientDenom
-    ]);
+    patientSource.loadBundles([patientNumer, patientDenom]);
   });
 
   afterEach(() => patientSource.reset());
-
 
   it('should properly iterate test patients', () => {
     // Check first patient
@@ -46,32 +42,36 @@ describe('#R4 v4.0.1 with QICore 4.1.0 Data', () => {
     expect(patientSource.currentPatient()).to.not.equal(patientSource.currentPatient());
   });
 
-  it('should find patient birthDate', () =>{
+  it('should find patient birthDate', () => {
     const pt = patientSource.currentPatient();
     // cql-execution v1.3.2 currently doesn't export the new Date class, so we need to use the .getDate() workaround
-    expect(compact(pt.get('birthDate'))).to.deep.equal({ value: new cql.DateTime.parse('1995-01-01').getDate() });
+    expect(compact(pt.get('birthDate'))).to.deep.equal({
+      value: new cql.DateTime.parse('1995-01-01').getDate()
+    });
     expect(pt.get('birthDate.value')).to.deep.equal(new cql.DateTime.parse('1995-01-01').getDate());
   });
 
-  it('should find patient extensions', () =>{
+  it('should find patient extensions', () => {
     const pt = patientSource.currentPatient();
     const extensions = pt.get('extension');
     expect(extensions).to.have.length(2);
     //Check the first and last ones
     expect(compact(extensions[0])).to.deep.equal({
       url: { value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race' },
-      extension: [ {
-        url: { value: 'ombCategory' },
-        value: {
-          system: { value: 'urn:oid:2.16.840.1.113883.6.238' },
-          code: { value: '2028-9' },
-          display: { value: 'Asian' }
+      extension: [
+        {
+          url: { value: 'ombCategory' },
+          value: {
+            system: { value: 'urn:oid:2.16.840.1.113883.6.238' },
+            code: { value: '2028-9' },
+            display: { value: 'Asian' }
+          }
         }
-      } ]
+      ]
     });
   });
 
-  it('should find records by type name (e.g., Encounter)', () =>{
+  it('should find records by type name (e.g., Encounter)', () => {
     const pt = patientSource.currentPatient();
     const encounters = pt.findRecords('Encounter');
     expect(encounters).to.have.length(1);
@@ -80,7 +80,7 @@ describe('#R4 v4.0.1 with QICore 4.1.0 Data', () => {
     expect(paymentReconciliations).to.be.empty;
   });
 
-  it('should find records by model name and type name (e.g., FHIR.Encounter)', () =>{
+  it('should find records by model name and type name (e.g., FHIR.Encounter)', () => {
     const pt = patientSource.currentPatient();
     const encounters = pt.findRecords('FHIR.Encounter');
     expect(encounters).to.have.length(1);
@@ -89,7 +89,7 @@ describe('#R4 v4.0.1 with QICore 4.1.0 Data', () => {
     expect(paymentReconciliations).to.be.empty;
   });
 
-  it('should find records by model URL and type name (e.g., {http://hl7.org/fhir}Encounter)', () =>{
+  it('should find records by model URL and type name (e.g., {http://hl7.org/fhir}Encounter)', () => {
     const pt = patientSource.currentPatient();
     const encounters = pt.findRecords('{http://hl7.org/fhir}Encounter');
     expect(encounters).to.have.length(1);
@@ -98,16 +98,20 @@ describe('#R4 v4.0.1 with QICore 4.1.0 Data', () => {
     expect(paymentReconciliations).to.be.empty;
   });
 
-  it('should find records by QICore profile URL (e.g., http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter)', () =>{
+  it('should find records by QICore profile URL (e.g., http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter)', () => {
     const pt = patientSource.currentPatient();
-    const encounters = pt.findRecords('http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter');
+    const encounters = pt.findRecords(
+      'http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter'
+    );
     expect(encounters).to.have.length(1);
     expect(encounters.every(c => c.getTypeInfo().name === 'Encounter')).to.be.true;
-    const coverage = pt.findRecords('http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage');
+    const coverage = pt.findRecords(
+      'http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage'
+    );
     expect(coverage).to.be.empty;
   });
 
-  it('should find a single record', () =>{
+  it('should find a single record', () => {
     const pt = patientSource.currentPatient();
     const encounter = pt.findRecord('Encounter');
     expect(encounter.getTypeInfo().name).to.equal('Encounter');
@@ -129,7 +133,6 @@ function compact(obj) {
     if (value !== undefined) {
       compacted[prop] = compact(value);
     }
-
   }
   return compacted;
 }

--- a/test/qicore410_test.js
+++ b/test/qicore410_test.js
@@ -4,6 +4,7 @@ const { expect } = require('chai');
 
 const patientNumer = require('./fixtures/qicore4/tests-numer-EXM124-bundle.json');
 const patientDenom = require('./fixtures/qicore4/tests-denom-EXM124-bundle.json');
+const encounterDetails = { datatype: 'Encounter' };
 
 describe('#R4 v4.0.1 with QICore 4.1.0 Data', () => {
   let patientSource;
@@ -98,10 +99,12 @@ describe('#R4 v4.0.1 with QICore 4.1.0 Data', () => {
     expect(paymentReconciliations).to.be.empty;
   });
 
+  //AKA the ask here is to see if adding proper retrieveDetails in the findRecords call here makes this test pass
   it('should find records by QICore profile URL (e.g., http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter)', () => {
     const pt = patientSource.currentPatient();
     const encounters = pt.findRecords(
-      'http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter'
+      'http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter',
+      encounterDetails
     );
     expect(encounters).to.have.length(1);
     expect(encounters.every(c => c.getTypeInfo().name === 'Encounter')).to.be.true;

--- a/test/qicore410_test.js
+++ b/test/qicore410_test.js
@@ -99,7 +99,6 @@ describe('#R4 v4.0.1 with QICore 4.1.0 Data', () => {
     expect(paymentReconciliations).to.be.empty;
   });
 
-  //AKA the ask here is to see if adding proper retrieveDetails in the findRecords call here makes this test pass
   it('should find records by QICore profile URL (e.g., http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter)', () => {
     const pt = patientSource.currentPatient();
     const encounters = pt.findRecords(

--- a/test/stu3_test.js
+++ b/test/stu3_test.js
@@ -358,7 +358,7 @@ describe('#STU3', () => {
   it('should support id on list of primitives', () => {
     const pt = patientSource.currentPatient();
     expect(compact(pt.get('address')[0].get('line'))).to.deep.equal([
-      { value: "172 O'Keefe Station" },
+      { value: '172 O\'Keefe Station' },
       { id: '2468', value: 'Floor 5' },
       { value: 'Apt. C' }
     ]);

--- a/test/stu3_test.js
+++ b/test/stu3_test.js
@@ -358,7 +358,7 @@ describe('#STU3', () => {
   it('should support id on list of primitives', () => {
     const pt = patientSource.currentPatient();
     expect(compact(pt.get('address')[0].get('line'))).to.deep.equal([
-      { value: '172 O\'Keefe Station' },
+      { value: "172 O'Keefe Station" },
       { id: '2468', value: 'Floor 5' },
       { value: 'Apt. C' }
     ]);


### PR DESCRIPTION
(As part of this change I pulled in the changes that were made on the fallback branch in order to test and to have patient fixtures)
## code changes:

`/src/fhir.js`- added an option parameter to findRecords to allow for searching by the retrievedDetails.datatype, if the parameter is not present it will fall back to to the old method of getting the classinfo and finding the records, modified both regular patient and async patient classes
`/test/qicore410_test.js `- brought over the testing changes from the fall back branch
`/test/fixtures/qicore4 `- added the fixtures needed to make the tests runs
## Testing

Run yarn test, see that all tests pass
Pull fqm-execution master
Using the measure bundle [here](https://github.com/cqframework/ecqm-content-qicore-2020/blob/master/bundles/measure/EXM124v7QICore4/EXM124v7QICore4-bundle.json) and the patient [here](url) run fqm execution and see that there are profile errors
Pull this branch and run npm link with this branch of cql-exec fhir
Re-run fqm execution and see that those errors are no longer present, however there may still be issues with the calculation. (the results may be incorrect)

## Testing async patients: (these are all the fqm-execution cli options)
You should upload the qi core measure and patient bundle to a running deqm-test-server
Then  use http://localhost:3000/4_0_1 as the --fhir-server-url CLI option
And the ID of the patient resource in the qi core numerator patient for the --patient-ids CLI option
There are further details about testing with async patient sources in this pr [here](https://github.com/projecttacoma/fqm-execution/pull/112)