### PR TITLE
meta.profile validation

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -404,7 +404,7 @@ class Patient extends FHIRObject {
       .filter(e => {
         if (e.resource && e.resource.resourceType == resourceType) {
           if (this._shouldCheckProfile) {
-            return e.resource.meta.profile.includes(profile);
+            return e.resource?.meta?.profile?.includes(profile);
           }
           return true;
         }

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -404,7 +404,11 @@ class Patient extends FHIRObject {
       .filter(e => {
         if (e.resource && e.resource.resourceType == resourceType) {
           if (this._shouldCheckProfile) {
-            return e.resource?.meta?.profile?.includes(profile);
+            return (
+              e.resource.meta &&
+              e.resource.meta.profile &&
+              e.resource.meta.profile.includes(profile)
+            );
           }
           return true;
         }

--- a/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
+++ b/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
@@ -109,9 +109,7 @@
           {
             "use": "official",
             "family": "McCullough561",
-            "given": [
-              "Luna60"
-            ]
+            "given": ["Luna60"]
           }
         ],
         "telecom": [
@@ -140,15 +138,8 @@
                 ]
               }
             ],
-            "line": [
-              "386 Stokes Center",
-              "Floor 5",
-              "Apt. C"
-            ],
-            "_line": [
-              null,
-              { "id": "2468" }
-            ],
+            "line": ["386 Stokes Center", "Floor 5", "Apt. C"],
+            "_line": [null, { "id": "2468" }],
             "city": "Acushnet",
             "state": "Massachusetts",
             "postalCode": "02743",
@@ -219,9 +210,7 @@
         ],
         "address": [
           {
-            "line": [
-              "88 LEWIS BAY ROAD"
-            ],
+            "line": ["88 LEWIS BAY ROAD"],
             "city": "HYANNIS",
             "state": "MA",
             "postalCode": "02601",
@@ -249,19 +238,13 @@
         "name": [
           {
             "family": "Leannon79",
-            "given": [
-              "Stanford577"
-            ],
-            "prefix": [
-              "Dr."
-            ]
+            "given": ["Stanford577"],
+            "prefix": ["Dr."]
           }
         ],
         "address": [
           {
-            "line": [
-              "88 LEWIS BAY ROAD"
-            ],
+            "line": ["88 LEWIS BAY ROAD"],
             "city": "HYANNIS",
             "state": "MA",
             "postalCode": "02601",
@@ -283,10 +266,12 @@
         "status": "finished",
         "_status": {
           "id": "12345",
-          "extension" : [ {
-             "url" : "http://example.org/fhir/StructureDefinition/originalText",
-             "valueCode" : "completed"
-          }]
+          "extension": [
+            {
+              "url": "http://example.org/fhir/StructureDefinition/originalText",
+              "valueCode": "completed"
+            }
+          ]
         },
         "class": {
           "code": "wellness"
@@ -839,9 +824,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -859,9 +842,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "productOrService": {
               "coding": [
                 {
@@ -879,9 +860,7 @@
           },
           {
             "sequence": 4,
-            "informationSequence": [
-              3
-            ],
+            "informationSequence": [3],
             "productOrService": {
               "coding": [
                 {
@@ -899,9 +878,7 @@
           },
           {
             "sequence": 5,
-            "informationSequence": [
-              4
-            ],
+            "informationSequence": [4],
             "productOrService": {
               "coding": [
                 {
@@ -1078,9 +1055,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -1208,9 +1183,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "category": {
               "coding": [
                 {
@@ -1338,9 +1311,7 @@
           },
           {
             "sequence": 4,
-            "informationSequence": [
-              3
-            ],
+            "informationSequence": [3],
             "category": {
               "coding": [
                 {
@@ -1468,9 +1439,7 @@
           },
           {
             "sequence": 5,
-            "informationSequence": [
-              4
-            ],
+            "informationSequence": [4],
             "category": {
               "coding": [
                 {
@@ -1687,6 +1656,9 @@
       "resource": {
         "resourceType": "Condition",
         "id": "9934bc4f-58af-4ecf-bb70-b7cc31987fc5",
+        "meta": {
+          "profile": ["Condition"]
+        },
         "clinicalStatus": {
           "coding": [
             {
@@ -1800,9 +1772,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -1816,7 +1786,7 @@
           }
         ],
         "total": {
-          "value": 125.00,
+          "value": 125.0,
           "currency": "USD"
         }
       },
@@ -1993,9 +1963,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "category": {
               "coding": [
                 {
@@ -2043,7 +2011,7 @@
               "text": "Submitted Amount"
             },
             "amount": {
-              "value": 125.00,
+              "value": 125.0,
               "currency": "USD"
             }
           }
@@ -2413,9 +2381,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -2429,7 +2395,7 @@
           }
         ],
         "total": {
-          "value": 125.00,
+          "value": 125.0,
           "currency": "USD"
         }
       },
@@ -2606,9 +2572,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "category": {
               "coding": [
                 {
@@ -2656,7 +2620,7 @@
               "text": "Submitted Amount"
             },
             "amount": {
-              "value": 125.00,
+              "value": 125.0,
               "currency": "USD"
             }
           }
@@ -3092,9 +3056,7 @@
           },
           {
             "sequence": 2,
-            "procedureSequence": [
-              1
-            ],
+            "procedureSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -3600,9 +3562,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -3616,7 +3576,7 @@
           }
         ],
         "total": {
-          "value": 125.00,
+          "value": 125.0,
           "currency": "USD"
         }
       },
@@ -3793,9 +3753,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "category": {
               "coding": [
                 {
@@ -3843,7 +3801,7 @@
               "text": "Submitted Amount"
             },
             "amount": {
-              "value": 125.00,
+              "value": 125.0,
               "currency": "USD"
             }
           }
@@ -4032,9 +3990,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -4048,7 +4004,7 @@
           }
         ],
         "total": {
-          "value": 125.00,
+          "value": 125.0,
           "currency": "USD"
         }
       },
@@ -4225,9 +4181,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "category": {
               "coding": [
                 {
@@ -4275,7 +4229,7 @@
               "text": "Submitted Amount"
             },
             "amount": {
-              "value": 125.00,
+              "value": 125.0,
               "currency": "USD"
             }
           }
@@ -4849,9 +4803,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -4869,9 +4821,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "productOrService": {
               "coding": [
                 {
@@ -4889,9 +4839,7 @@
           },
           {
             "sequence": 4,
-            "informationSequence": [
-              3
-            ],
+            "informationSequence": [3],
             "productOrService": {
               "coding": [
                 {
@@ -4909,9 +4857,7 @@
           },
           {
             "sequence": 5,
-            "informationSequence": [
-              4
-            ],
+            "informationSequence": [4],
             "productOrService": {
               "coding": [
                 {
@@ -5088,9 +5034,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -5218,9 +5162,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "category": {
               "coding": [
                 {
@@ -5348,9 +5290,7 @@
           },
           {
             "sequence": 4,
-            "informationSequence": [
-              3
-            ],
+            "informationSequence": [3],
             "category": {
               "coding": [
                 {
@@ -5478,9 +5418,7 @@
           },
           {
             "sequence": 5,
-            "informationSequence": [
-              4
-            ],
+            "informationSequence": [4],
             "category": {
               "coding": [
                 {
@@ -6102,9 +6040,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -6118,7 +6054,7 @@
           }
         ],
         "total": {
-          "value": 125.00,
+          "value": 125.0,
           "currency": "USD"
         }
       },
@@ -6295,9 +6231,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "category": {
               "coding": [
                 {
@@ -6345,7 +6279,7 @@
               "text": "Submitted Amount"
             },
             "amount": {
-              "value": 125.00,
+              "value": 125.0,
               "currency": "USD"
             }
           }
@@ -6831,9 +6765,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -6851,9 +6783,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "productOrService": {
               "coding": [
                 {
@@ -7030,9 +6960,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -7160,9 +7088,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "category": {
               "coding": [
                 {
@@ -7788,9 +7714,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -7808,9 +7732,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "productOrService": {
               "coding": [
                 {
@@ -7987,9 +7909,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -8117,9 +8037,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "category": {
               "coding": [
                 {
@@ -8832,9 +8750,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -8852,9 +8768,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "productOrService": {
               "coding": [
                 {
@@ -8872,9 +8786,7 @@
           },
           {
             "sequence": 4,
-            "procedureSequence": [
-              1
-            ],
+            "procedureSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -9051,9 +8963,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -9181,9 +9091,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "category": {
               "coding": [
                 {
@@ -9640,9 +9548,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -9656,7 +9562,7 @@
           }
         ],
         "total": {
-          "value": 125.00,
+          "value": 125.0,
           "currency": "USD"
         }
       },
@@ -9833,9 +9739,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "category": {
               "coding": [
                 {
@@ -9883,7 +9787,7 @@
               "text": "Submitted Amount"
             },
             "amount": {
-              "value": 125.00,
+              "value": 125.0,
               "currency": "USD"
             }
           }
@@ -10416,9 +10320,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -10436,9 +10338,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "productOrService": {
               "coding": [
                 {
@@ -10615,9 +10515,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -10745,9 +10643,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "category": {
               "coding": [
                 {
@@ -11370,9 +11266,7 @@
           },
           {
             "sequence": 2,
-            "procedureSequence": [
-              1
-            ],
+            "procedureSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -12217,9 +12111,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -12237,9 +12129,7 @@
           },
           {
             "sequence": 3,
-            "procedureSequence": [
-              1
-            ],
+            "procedureSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -12257,7 +12147,7 @@
           }
         ],
         "total": {
-          "value": 1243.50,
+          "value": 1243.5,
           "currency": "USD"
         }
       },
@@ -12416,9 +12306,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -12685,7 +12573,7 @@
               "text": "Submitted Amount"
             },
             "amount": {
-              "value": 1243.50,
+              "value": 1243.5,
               "currency": "USD"
             }
           }
@@ -13390,9 +13278,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -13410,9 +13296,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "productOrService": {
               "coding": [
                 {
@@ -13430,9 +13314,7 @@
           },
           {
             "sequence": 4,
-            "informationSequence": [
-              3
-            ],
+            "informationSequence": [3],
             "productOrService": {
               "coding": [
                 {
@@ -13450,9 +13332,7 @@
           },
           {
             "sequence": 5,
-            "informationSequence": [
-              4
-            ],
+            "informationSequence": [4],
             "productOrService": {
               "coding": [
                 {
@@ -13470,9 +13350,7 @@
           },
           {
             "sequence": 6,
-            "informationSequence": [
-              5
-            ],
+            "informationSequence": [5],
             "productOrService": {
               "coding": [
                 {
@@ -13490,9 +13368,7 @@
           },
           {
             "sequence": 7,
-            "procedureSequence": [
-              1
-            ],
+            "procedureSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -13669,9 +13545,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -13799,9 +13673,7 @@
           },
           {
             "sequence": 3,
-            "informationSequence": [
-              2
-            ],
+            "informationSequence": [2],
             "category": {
               "coding": [
                 {
@@ -13929,9 +13801,7 @@
           },
           {
             "sequence": 4,
-            "informationSequence": [
-              3
-            ],
+            "informationSequence": [3],
             "category": {
               "coding": [
                 {
@@ -14059,9 +13929,7 @@
           },
           {
             "sequence": 5,
-            "informationSequence": [
-              4
-            ],
+            "informationSequence": [4],
             "category": {
               "coding": [
                 {
@@ -14189,9 +14057,7 @@
           },
           {
             "sequence": 6,
-            "informationSequence": [
-              5
-            ],
+            "informationSequence": [5],
             "category": {
               "coding": [
                 {
@@ -14838,9 +14704,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -14854,7 +14718,7 @@
           }
         ],
         "total": {
-          "value": 125.00,
+          "value": 125.0,
           "currency": "USD"
         }
       },
@@ -15031,9 +14895,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "category": {
               "coding": [
                 {
@@ -15081,7 +14943,7 @@
               "text": "Submitted Amount"
             },
             "amount": {
-              "value": 125.00,
+              "value": 125.0,
               "currency": "USD"
             }
           }
@@ -16174,9 +16036,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -16353,9 +16213,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -16984,9 +16842,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -17163,9 +17019,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -17794,9 +17648,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -17973,9 +17825,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -18644,9 +18494,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -18664,9 +18512,7 @@
           },
           {
             "sequence": 3,
-            "procedureSequence": [
-              1
-            ],
+            "procedureSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -18843,9 +18689,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {
@@ -19302,9 +19146,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -19318,7 +19160,7 @@
           }
         ],
         "total": {
-          "value": 125.00,
+          "value": 125.0,
           "currency": "USD"
         }
       },
@@ -19495,9 +19337,7 @@
           },
           {
             "sequence": 2,
-            "diagnosisSequence": [
-              1
-            ],
+            "diagnosisSequence": [1],
             "category": {
               "coding": [
                 {
@@ -19545,7 +19385,7 @@
               "text": "Submitted Amount"
             },
             "amount": {
-              "value": 125.00,
+              "value": 125.0,
               "currency": "USD"
             }
           }
@@ -20034,9 +19874,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "productOrService": {
               "coding": [
                 {
@@ -20213,9 +20051,7 @@
           },
           {
             "sequence": 2,
-            "informationSequence": [
-              1
-            ],
+            "informationSequence": [1],
             "category": {
               "coding": [
                 {

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -447,6 +447,27 @@ describe('#R4 v4.0.1', () => {
   });
 });
 
+describe(`PatientSource with shouldCheckProfile = true`, () => {
+  let patientSource;
+  before(() => {
+    patientSource = cqlfhir.PatientSource.FHIRv401(true);
+  });
+
+  beforeEach(() => {
+    patientSource.loadBundles([patientLuna, patientJohnnie]);
+  });
+
+  afterEach(() => patientSource.reset());
+
+  it('correctly filters out resources without the proper meta.profile', () => {
+    const pt = patientSource.currentPatient();
+    const conditions = pt.findRecords('Condition');
+    expect(conditions).to.have.length(1);
+    expect(conditions.every(c => c.getTypeInfo().name === 'Condition')).to.be.true;
+    expect(conditions[0].meta.profile[0].value).equal('Condition');
+  });
+});
+
 describe(`Async Patient Source`, () => {
   it('correctly returns patient data with valid currentPatient() call', async () => {
     const aps = cqlfhir.AsyncPatientSource.FHIRv401(TEST_SERVER_URL);

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -509,6 +509,29 @@ describe('Async Patient', () => {
     );
   });
 
+  it('correctly executes a findRecords() with shouldCheckProfile flag set to true', async () => {
+    nock(TEST_SERVER_URL)
+      .get(`/Condition?patient=Patient/${TEST_PATIENT_SOURCE_IDS[0]}&_profile=Condition`)
+      .reply(200, EXAMPLE_EMPTY_SEARCH);
+
+    nock(TEST_SERVER_URL)
+      .get(`/Condition?asserter=Patient/${TEST_PATIENT_SOURCE_IDS[0]}&_profile=Condition`)
+      .reply(200, EXAMPLE_NON_EMPTY_CONDITION_SEARCH);
+    const modelInfo = load(FHIRv401XML);
+    const testPatient = new cqlfhir.AsyncPatient(
+      patientLuna.entry[0].resource,
+      modelInfo,
+      TEST_SERVER_INSTANCE,
+      true
+    );
+
+    const records = await testPatient.findRecords('Condition');
+    const classInfo = modelInfo.findClass('Condition');
+    expect(JSON.stringify(records)).equal(
+      JSON.stringify([new cqlfhir.FHIRObject(conditionResource, classInfo, modelInfo)])
+    );
+  });
+
   it('correctly executes a findRecords() for resource that cannot reference patient', async () => {
     nock(TEST_SERVER_URL).get(`/Location`).reply(200, EXAMPLE_NON_EMPTY_LOCATION_SEARCH);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1923,9 +1923,9 @@ minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mocha@9.2.0:
   version "9.2.0"


### PR DESCRIPTION
## Summary
Added a flag and functionality that allows both synchronous and asynchronous patient sources to validate the profile passed into a findRecords call against the `meta.profile` of the found resources

### New Behavior
Patient, AsyncPatient, PatientSource, and AsyncPatientSource now have an additional argument, `shouldCheckProfiles` in their constructor as well as in the functions that call their constructor. This flag, when true, unlocks a conditional in the findRecords functions of Patient and AsyncPatient that will filter out records found that do not have the passed in `profile` listed in their `meta.profile` array.

### Code Changes
- Added `shouldCheckProfiles` flag to `AsyncPatientSource`, `AsyncPatient`, `PatientSource`, and `Patient`
- Added functionality inside the `findRecords` function of `Patient` to filter out any found resources that do not have the passed in profile in their `meta.profile` array
- Added functionality inside `AsyncPatient` to add a `_profile` arg to the server query to filter out all resources that do not have the passed in profile listed in their `meta.profile` array
- Added unit testing for new functionality

## Testing Guidance
- Run the unit tests with `yarn run test`
- Ping me for modified EXM130 patient bundles. The validation is still not capable of validating a us-core profile against a Patient profile. Since all the connectathon bundles contain this mismatch, I had to alter the profiles in the patient bundles to change them to base FHIR instead of us-core
- Open fqm-execution and change line 166 to read: 
- `patientSource = AsyncPatientSource.FHIRv401(program.fhirServerUrl, true);`
- Change line 169 to read: `patientSource = PatientSource.FHIRv401(true);`
- Feel free to ping me for a list of tests commands used, but I'll explain the different setups here.
- Run a reports calculation on EXM130 using the altered numerator patient bundle with the `--as-patient-source` flag. You should see the patient calculate into the numerator
- Now, change the `meta.profile` of Procedure `numer-EXM130-1` in any way you like (I just added a 1 to the end)
- Rerun the same report and the patient should evaluate into the denominator, as the necessary procedure is no longer evaluated
- Now, open the test server repo and run `npm run db:reset` then `npm run connectathon-upload`
- Open insomnia, and `POST` the altered numerator transaction bundle to `http://localhost:3000/4_0_1`. This should update the profiles of the stored resources.
- Now, run a reports calculation adding in `"numer-EXM130"` for the `--patient-ids` flag and removing the `-p` flag
- If you did not change the manipulated Procedure profile back, the patient should calculate into the denominator. Otherwise, numerator
- Change the Procedure profile to either fix or break the validation, and rerun. You should see the opposite.