### PR TITLE
remove duplicate shouldCheckProfile from AsyncPatient

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -429,7 +429,6 @@ class AsyncPatient extends FHIRObject {
       : modelInfo.patientClassName;
     const ptClass = modelInfo.findClass(patientClass);
     super(patientData, ptClass, modelInfo);
-    this._shouldCheckProfile = shouldCheckProfile;
 
     // Define a "private" un-enumerable property to hold the patient data
     Object.defineProperty(this, '_patientData', {


### PR DESCRIPTION
Calling myself out - I didn't catch the duplicate `shouldCheckProfile` when reviewing https://github.com/projecttacoma/cql-exec-fhir/pull/4. 

This PR removes the duplicate `shouldCheckProfile` in the constructor of the AsyncPatient class.