### PR TITLE
Update module.export to include load.js

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const cql = require('cql-execution');
-const load = require('./load');
+const { load } = require('./load');
 const patientCompartmentDefinition = require('./compartmentdefinition-patient.json');
 const FHIRv102XML = require('./modelInfos/fhir-modelinfo-1.0.2.xml.js');
 const FHIRv300XML = require('./modelInfos/fhir-modelinfo-3.0.0.xml.js');

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,4 @@
-module.exports = require('./fhir');
+module.exports = {
+  ...require('./fhir'),
+  ...require('./load')
+};

--- a/src/load.js
+++ b/src/load.js
@@ -384,4 +384,4 @@ function stripNS(str) {
   return str.replace(/.*:/, '');
 }
 
-module.exports = load;
+module.exports = { load };

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -3,7 +3,7 @@ const cqlfhir = require('../src/index');
 const { expect } = require('chai');
 const nock = require('nock');
 const axios = require('axios');
-const load = require('../src/load');
+const { load } = require('../src/load');
 
 const conditionResource = require('./fixtures/r4/Condition_f201.json');
 const locationResource = require('./fixtures/r4/Location.json');


### PR DESCRIPTION
# Summary
Adds `load.js` to `module.exports`.

## New behavior
No new behavior in this repo.

The `load()` function is needed in [cql-exec-fhir-mongo](https://github.com/projecttacoma/cql-exec-fhir-mongo). This PR adds it to `module.exports` so it can be used in cql-exec-fhir-mongo when cql-exec-fhir is brought in as a dependency.

## Code changes
Updated `module.exports` in `src/index.js` and other small changes.

# Testing guidance
Run `yarn test` to make sure the `load()` function still works in all the unit tests.