### PR TITLE
Group support for AsyncPatientSource

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -153,7 +153,8 @@ class AsyncPatientSource {
    */
   async loadGroupId(id) {
     try {
-      const group = await this.fhirClient.get(`/Group/${id}`);
+      const response = await this.fhirClient.get(`/Group/${id}`);
+      const group = response.data;
       const ids = group.member.map(m => {
         return m.entity.reference.split('/')[1];
       });

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -148,7 +148,7 @@ class AsyncPatientSource {
   }
 
   /**
-   * Load patient Ids that appear in the Group resource member
+   * Load patient ids that appear in the Group resource member
    * @param {string} id Group resource identifier
    */
   async loadGroupId(id) {

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -147,6 +147,24 @@ class AsyncPatientSource {
     this._patientIds = this._patientIds.concat(ids);
   }
 
+  /**
+   * Load patient Ids that appear in the Group resource member
+   * @param {string} id Group resource identifier
+   */
+  async loadGroupId(id) {
+    try {
+      const group = await this.fhirClient.get(`/Group/${id}`);
+      const ids = group.member.map(m => {
+        return m.entity.reference.split('/')[1];
+      });
+      this.loadPatientIds(ids);
+    } catch (e) {
+      throw new Error(
+        `Unable to retrieve Group/${id} from server. Responded with message: ${e.message}`
+      );
+    }
+  }
+
   async currentPatient() {
     if (this._index < this._patientIds.length) {
       const id = this._patientIds[this._index];

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -531,7 +531,7 @@ describe('Async Patient Source with group Id', () => {
     expect(response.get('id').value).equal(patientLuna.entry[0].resource.id);
   });
 
-  it('correctly returns patient data with valid nextPatient() call when group Id is used to obtain patient ids', async () => {
+  it('correctly returns patient data with valid nextPatient() call when group id is used to obtain patient ids', async () => {
     const aps = cqlfhir.AsyncPatientSource.FHIRv401(TEST_SERVER_URL);
     nock(TEST_SERVER_URL)
       .get(`/Patient/${TEST_PATIENT_SOURCE_IDS[1]}`)
@@ -543,15 +543,17 @@ describe('Async Patient Source with group Id', () => {
     expect(response.get('id').value).equal(patientJohnnie.entry[0].resource.id);
   });
 
-  it('throws correct error when specified group Id cannot be found on the server', async () => {
+  it('throws correct error when specified group id cannot be found on the server', async () => {
+    const INVALID_ID = 'INVALID_ID';
     const aps = cqlfhir.AsyncPatientSource.FHIRv401(TEST_SERVER_URL);
+    nock(TEST_SERVER_URL).get(`/Group/${INVALID_ID}`).reply(400);
+
     try {
-      await aps.loadGroupId('INVALID_ID');
-      expect.fail(
-        'loadGroupId() failed to throw error when group Id cannot be found on the server'
-      );
+      await aps.loadGroupId(INVALID_ID);
     } catch (e) {
-      expect(e.message).to.include(`Unable to retrieve Group/INVALID_ID from server.`);
+      expect(e.message).equal(
+        `Unable to retrieve Group/INVALID_ID from server. Responded with message: Request failed with status code 400`
+      );
     }
   });
 });

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -518,7 +518,7 @@ describe(`Async Patient Source`, () => {
   });
 });
 
-describe('Async Patient Source with group Id', () => {
+describe('Async Patient Source with group id', () => {
   it('correctly returns patient data with valid currentPatient() call when group Id is used to obtain patient ids', async () => {
     const aps = cqlfhir.AsyncPatientSource.FHIRv401(TEST_SERVER_URL);
     nock(TEST_SERVER_URL)

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -25,6 +25,17 @@ const TEST_PATIENT_SOURCE_IDS = [
   patientJohnnie.entry[0].resource.id
 ];
 
+const TEST_GROUP = {
+  resourceType: 'Group',
+  id: 'test-group',
+  type: 'person',
+  actual: 'true',
+  member: [
+    { entity: { reference: `Patient/${patientLuna.entry[0].resource.id}` } },
+    { entity: { reference: `Patient/${patientJohnnie.entry[0].resource.id}` } }
+  ]
+};
+
 const EXAMPLE_EMPTY_SEARCH = {
   resourceType: 'Bundle',
   type: 'searchset',
@@ -504,6 +515,44 @@ describe(`Async Patient Source`, () => {
     aps.loadPatientIds(TEST_PATIENT_SOURCE_IDS);
     const response = await aps.nextPatient();
     expect(response.get('id').value).equal(patientJohnnie.entry[0].resource.id);
+  });
+});
+
+describe('Async Patient Source with group Id', () => {
+  it('correctly returns patient data with valid currentPatient() call when group Id is used to obtain patient ids', async () => {
+    const aps = cqlfhir.AsyncPatientSource.FHIRv401(TEST_SERVER_URL);
+    nock(TEST_SERVER_URL)
+      .get(`/Patient/${TEST_PATIENT_SOURCE_IDS[0]}`)
+      .reply(200, patientLuna.entry[0].resource);
+    nock(TEST_SERVER_URL).get(`/Group/${TEST_GROUP.id}`).reply(200, TEST_GROUP);
+
+    await aps.loadGroupId(TEST_GROUP.id);
+    const response = await aps.currentPatient();
+    expect(response.get('id').value).equal(patientLuna.entry[0].resource.id);
+  });
+
+  it('correctly returns patient data with valid nextPatient() call when group Id is used to obtain patient ids', async () => {
+    const aps = cqlfhir.AsyncPatientSource.FHIRv401(TEST_SERVER_URL);
+    nock(TEST_SERVER_URL)
+      .get(`/Patient/${TEST_PATIENT_SOURCE_IDS[1]}`)
+      .reply(200, patientJohnnie.entry[0].resource);
+    nock(TEST_SERVER_URL).get(`/Group/${TEST_GROUP.id}`).reply(200, TEST_GROUP);
+
+    await aps.loadGroupId(TEST_GROUP.id);
+    const response = await aps.nextPatient();
+    expect(response.get('id').value).equal(patientJohnnie.entry[0].resource.id);
+  });
+
+  it('throws correct error when specified group Id cannot be found on the server', async () => {
+    const aps = cqlfhir.AsyncPatientSource.FHIRv401(TEST_SERVER_URL);
+    try {
+      await aps.loadGroupId('INVALID_ID');
+      expect.fail(
+        'loadGroupId() failed to throw error when group Id cannot be found on the server'
+      );
+    } catch (e) {
+      expect(e.message).to.include(`Unable to retrieve Group/INVALID_ID from server.`);
+    }
   });
 });
 


### PR DESCRIPTION
# Summary
Adds support for a Group reference to be used for populating patient ids for the AsyncPatientSource class.

## New behavior
Rather than taking in a list of patient ids to use in `currentPatient()`, the user can now specify the id of a Group resource. The patient ids referenced in the Group resource are used to create`AsyncPatient` instances.

## Code changes
* New function in the AsyncPatientSource class called `loadGroupId()` that grabs the patient ids referenced in the Group resource and populates the `patientIds` array
* Added unit testing for Group support, which creates a test Group resource that references test patients

# Testing guidance
* Run the unit tests with `yarn run test`
* To test with `fqm-execution`, see [the corresponding PR in fqm-execution](https://github.com/projecttacoma/fqm-execution/pull/123). From fqm-execution, link to this cql-exec-fhir branch and follow the testing guidance listed in the fqm-execution PR.