### PR TITLE
Throw error when request for Patient resource does not match requested profile

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -471,7 +471,11 @@ class AsyncPatient extends FHIRObject {
     const resourceType = classInfo.name.replace(/^FHIR\./, '');
     // If the patient resource type is requested, return array with just this resource
     if (resourceType === 'Patient') {
-      return [this];
+      if (this._shouldCheckProfile && !this._patientData.meta?.profile?.includes(profile)) {
+        throw new Error(`Patient record with profile ${profile} was not found.`);
+      } else {
+        return [this];
+      }
     }
 
     const compartmentInfo = patientCompartmentDefinition.resource.filter(

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -437,6 +437,10 @@ class Patient extends FHIRObject {
       .map(e => {
         return new FHIRObject(e.resource, classInfo, this._modelInfo);
       });
+
+    if (this._shouldCheckProfile && resourceType === 'Patient' && records.length === 0) {
+      throw new Error(`Patient record with profile ${profile} was not found.`);
+    }
     return records;
   }
 }

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -471,7 +471,14 @@ class AsyncPatient extends FHIRObject {
     const resourceType = classInfo.name.replace(/^FHIR\./, '');
     // If the patient resource type is requested, return array with just this resource
     if (resourceType === 'Patient') {
-      if (this._shouldCheckProfile && !this._patientData.meta?.profile?.includes(profile)) {
+      if (
+        this._shouldCheckProfile &&
+        !(
+          this._patientData.meta &&
+          this._patientData.meta.profile &&
+          this._patientData.meta.profile.includes(profile)
+        )
+      ) {
         throw new Error(`Patient record with profile ${profile} was not found.`);
       } else {
         return [this];


### PR DESCRIPTION
When `shouldCheckProfile` is enabled any `findRecords` call for the Patient resource should throw an error if the requested patient profile is not found in the Patient `meta.profile` field.